### PR TITLE
Add METRLA dataset example

### DIFF
--- a/TGN++.ipynb
+++ b/TGN++.ipynb
@@ -17,7 +17,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install torch_geometric"
+        "!pip install torch_geometric torch_geometric_temporal"
       ],
       "metadata": {
         "colab": {
@@ -62,6 +62,32 @@
           ]
         }
       ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# METRLA dataset loader using torch_geometric_temporal\n",
+        "from torch_geometric_temporal.dataset import METRLADatasetLoader\n",
+        "from torch_geometric.data import TemporalData\n",
+        "\n",
+        "def load_metrla_temporal_data():\n",
+        "    loader = METRLADatasetLoader()\n",
+        "    dataset = loader.get_dataset(num_timesteps_in=1, num_timesteps_out=1)\n",
+        "    snapshot = next(iter(dataset))\n",
+        "    edge_index = torch.tensor(snapshot.edge_index, dtype=torch.long)\n",
+        "    src = edge_index[0]\n",
+        "    dst = edge_index[1]\n",
+        "    t = torch.zeros(src.size(0))\n",
+        "    msg = torch.tensor(snapshot.edge_weight, dtype=torch.float32).view(-1, 1)\n",
+        "    data = TemporalData(src=src, dst=dst, t=t, msg=msg)\n",
+        "    num_nodes = snapshot.x.shape[0]\n",
+        "    return data, num_nodes\n"
+      ],
+      "metadata": {
+        "id": "metrla_loader"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -1442,6 +1468,99 @@
       "source": [],
       "metadata": {
         "id": "vp0vLox-A6SH"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Train models on METRLA dataset\n",
+        "def train_tgn_on_metrla(num_nodes, epochs=10):\n",
+        "    data, _ = load_metrla_temporal_data()\n",
+        "    model = TGNLinkPredictor(num_nodes=num_nodes, msg_dim=data.msg.size(-1))\n",
+        "    optimizer = torch.optim.Adam(model.parameters(), lr=0.01, weight_decay=1e-4)\n",
+        "    y_true, y_score = [], []\n",
+        "    for epoch in range(epochs):\n",
+        "        model.memory.reset_state()\n",
+        "        loss_total = 0\n",
+        "        for i in range(data.t.size(0)):\n",
+        "            src, dst = data.src[i], data.dst[i]\n",
+        "            t = data.t[i]\n",
+        "            msg = data.msg[i].unsqueeze(0)\n",
+        "            with torch.no_grad():\n",
+        "                model.update_memory(src.unsqueeze(0), dst.unsqueeze(0), t.unsqueeze(0), msg)\n",
+        "            pred = model(src.unsqueeze(0), dst.unsqueeze(0))\n",
+        "            label = torch.tensor([1.0])\n",
+        "            loss = F.binary_cross_entropy_with_logits(pred.view(-1), label)\n",
+        "            optimizer.zero_grad()\n",
+        "            loss.backward()\n",
+        "            optimizer.step()\n",
+        "            loss_total += loss.item()\n",
+        "            y_true.append(label.item())\n",
+        "            y_score.append(torch.sigmoid(pred).item())\n",
+        "        print(f\"Epoch {epoch+1}, Loss: {loss_total:.4f}\")\n",
+        "    auc = roc_auc_score(y_true, y_score)\n",
+        "    y_pred_bin = [1 if p > 0.5 else 0 for p in y_score]\n",
+        "    f1 = f1_score(y_true, y_pred_bin)\n",
+        "    fpr, tpr, _ = roc_curve(y_true, y_score)\n",
+        "    print(f\"TGN ROC-AUC: {auc:.4f}, F1-score: {f1:.4f}\")\n",
+        "    return fpr, tpr, auc, f1\n",
+        "\n",
+        "def train_tgat_on_metrla(num_nodes, epochs=10):\n",
+        "    data, _ = load_metrla_temporal_data()\n",
+        "    model = TGATLinkPredictor(num_nodes=num_nodes, feat_dim=data.msg.size(-1))\n",
+        "    optimizer = torch.optim.Adam(model.parameters(), lr=0.01, weight_decay=1e-4)\n",
+        "    y_true, y_score = [], []\n",
+        "    for epoch in range(epochs):\n",
+        "        total_loss = 0\n",
+        "        for i in range(data.t.size(0)):\n",
+        "            src, dst = data.src[i], data.dst[i]\n",
+        "            t = data.t[i].unsqueeze(0)\n",
+        "            msg = data.msg[i]\n",
+        "            pred = model(src, dst, t, msg)\n",
+        "            label = torch.tensor([1.0])\n",
+        "            loss = F.binary_cross_entropy_with_logits(pred.view(-1), label)\n",
+        "            optimizer.zero_grad()\n",
+        "            loss.backward()\n",
+        "            optimizer.step()\n",
+        "            total_loss += loss.item()\n",
+        "            y_true.append(label.item())\n",
+        "            y_score.append(torch.sigmoid(pred).item())\n",
+        "        print(f\"Epoch {epoch+1}, Loss: {total_loss:.4f}\")\n",
+        "    auc = roc_auc_score(y_true, y_score)\n",
+        "    y_pred_bin = [1 if p > 0.5 else 0 for p in y_score]\n",
+        "    f1 = f1_score(y_true, y_pred_bin)\n",
+        "    fpr, tpr, _ = roc_curve(y_true, y_score)\n",
+        "    print(f\"TGAT ROC-AUC: {auc:.4f}, F1-score: {f1:.4f}\")\n",
+        "    return fpr, tpr, auc, f1\n",
+        "\n",
+        "def train_htgn_on_metrla(num_nodes):\n",
+        "    data, _ = load_metrla_temporal_data()\n",
+        "    return train_htgn(data, num_nodes)\n",
+        "\n",
+        "def run_metrla_experiment():\n",
+        "    data, num_nodes = load_metrla_temporal_data()\n",
+        "    fpr_tgn, tpr_tgn, auc_tgn, _ = train_tgn_on_metrla(num_nodes)\n",
+        "    fpr_tgat, tpr_tgat, auc_tgat, _ = train_tgat_on_metrla(num_nodes)\n",
+        "    fpr_htgn, tpr_htgn, auc_htgn, _ = train_htgn_on_metrla(num_nodes)\n",
+        "    plt.figure(figsize=(8,6))\n",
+        "    plt.plot(fpr_tgn, tpr_tgn, label=f'TGN (AUC = {auc_tgn:.3f})')\n",
+        "    plt.plot(fpr_tgat, tpr_tgat, label=f'TGAT (AUC = {auc_tgat:.3f})')\n",
+        "    plt.plot(fpr_htgn, tpr_htgn, label=f'HTGN (AUC = {auc_htgn:.3f})')\n",
+        "    plt.plot([0,1],[0,1],'k--',lw=1)\n",
+        "    plt.xlabel('False Positive Rate')\n",
+        "    plt.ylabel('True Positive Rate')\n",
+        "    plt.title('ROC Curve Comparison on METRLA')\n",
+        "    plt.legend()\n",
+        "    plt.grid(True)\n",
+        "    plt.tight_layout()\n",
+        "    plt.show()\n",
+        "\n",
+        "run_metrla_experiment()\n"
+      ],
+      "metadata": {
+        "id": "metrla_train"
       },
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
## Summary
- use METRLA dataset from `torch_geometric_temporal`
- install new dependency
- show how to train HTGN, TGN and TGAT on the same data

## Testing
- `python -m py_compile TGN++.ipynb` *(fails: cannot compile notebook)*

------
https://chatgpt.com/codex/tasks/task_e_68459e945d148320aa58a8850a621d2b